### PR TITLE
[#10] Fix the build dev failure issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Pipfile.lock
 *.tgz
 
 .pytest_cache/
+pysisyphus.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ language: python
 python:
   - "3.6"
 
-install:
+before_install:
   - pip install pipenv
-  - pipenv install
+
+install:
+  - make install
 
 script:
   - pipenv run pytest tests

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ publish:
 .PHONY: install uninstall clean
 
 install: $(PIP) uninstall
-	pip install $<
+	pip install $< -e .[dev]
 
 uninstall:
 	@[ -z "`pip list | grep $(PROJECT)`" ] || pip uninstall -y $(PROJECT)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     author_email='cmj.tw',
     packages=find_packages(),
     install_requires=['setproctitle', 'zmq', 'procname'],
+    extras_require={
+        'dev': ['pytest-mock']
+    },
     entry_points={
         'console_scripts': 'sisyphus = sisyphus.__main__:cli.run',
     },


### PR DESCRIPTION
	- Add extras_require in setup.py
	- install dev dependency in default `make install`
	- Move the environment setup to before_install